### PR TITLE
Add ollama-chat.nvim link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ See the [API documentation](./docs/api.md) for all endpoints.
 - [Emacs client](https://github.com/zweifisch/ollama)
 - [gen.nvim](https://github.com/David-Kunz/gen.nvim)
 - [ollama.nvim](https://github.com/nomnivore/ollama.nvim)
+- [ollama-chat.nvim](https://github.com/gerazov/ollama-chat.nvim)
 - [ogpt.nvim](https://github.com/huynle/ogpt.nvim)
 - [gptel Emacs client](https://github.com/karthink/gptel)
 - [Oatmeal](https://github.com/dustinblackman/oatmeal)


### PR DESCRIPTION
Awesome work guys :sunglasses: 

I've created a chat focused plugin for Neovim called [ollama-chat.nvim](https://github.com/gerazov/ollama-chat.nvim) that I enjoy using and that might be useful for others. I've added a link to it in the README here. If you think it's benefitial to have it there great :+1: 

The code is based on [ollama.nvim](https://github.com/nomnivore/ollama.nvim) which is a great plugin I found through your README.

